### PR TITLE
variável type alterada para code

### DIFF
--- a/os-arturito/src/main/java/com/outsmart/os_arturito/ErrorModule/OSError.kt
+++ b/os-arturito/src/main/java/com/outsmart/os_arturito/ErrorModule/OSError.kt
@@ -4,18 +4,18 @@ package com.outsmart.os_arturito.ErrorModule
  * Created by appsimples on 8/21/18.
  */
 class OSError(): Exception() {
-    var type: String = OSErrorTypes.OSBackendUnkownErrorType
+    var code: String = OSErrorTypes.OSBackendUnkownErrorType
     override var message: String = ""
     var devMessage: String = "Backend did not return devMessage"
     var httpCode: Int? = null
 
     constructor(
-            type: String,
+            code: String,
             message: String,
             devMessage: String,
             httpCode: Int? = null
     ) : this() {
-        this.type = type
+        this.code = code
         this.message = message
         this.devMessage = devMessage
         this.httpCode = httpCode ?: this.httpCode

--- a/os-arturito/src/main/java/com/outsmart/os_arturito/RXExtensions.kt
+++ b/os-arturito/src/main/java/com/outsmart/os_arturito/RXExtensions.kt
@@ -40,7 +40,7 @@ fun Completable.toLiveData(viewModel: BaseViewModel): LiveData<RequestResult<Uni
                             it.message?.let { errorCode = it }
                             it.localizedMessage?.let { devMessage = it }
                             (it as? OSError)?.let {
-                                errorCode = it.type
+                                errorCode = it.code
                                 errorMessage = it.message
                                 devMessage = it.devMessage
                             }
@@ -64,7 +64,7 @@ fun Completable.updateLiveData(viewModel: BaseViewModel, liveData: MutableLiveDa
                             it.message?.let { errorCode = it }
                             it.localizedMessage?.let { devMessage = it }
                             (it as? OSError)?.let {
-                                errorCode = it.type
+                                errorCode = it.code
                                 errorMessage = it.message
                                 devMessage = it.devMessage
                             }


### PR DESCRIPTION
Conforme discutido, o backend do casa estava configurado para mandar uma mensagem de erro deste tipo: 
{
    "error": {
        "message": "Ocorreu um erro desconhecido",
        "code": "UserAlreadyExists"
    }
}

arturito estava assim:
{
    "error": {
        "message": "Ocorreu um erro desconhecido",
        "type": "UserAlreadyExists"
    }
}
