### PR TITLE
Adapter com funcionalidades básicas sem perder a liberdade do nativo

### DIFF
--- a/os-arturito/src/main/java/com/outsmart/os_arturito/Components/ListComponent/LoadingViewHolder.kt
+++ b/os-arturito/src/main/java/com/outsmart/os_arturito/Components/ListComponent/LoadingViewHolder.kt
@@ -1,0 +1,19 @@
+package com.outsmart.os_arturito.Components.ListComponent
+
+import android.support.v7.widget.RecyclerView
+import android.view.View
+import android.view.ViewGroup
+
+class LoadingViewHolder(itemView: View) : OSAdapter.OSViewHolder(itemView) {
+
+    override fun bindView(position: Int) {
+        setLayoutParameterToMatchParent()
+    }
+
+    private fun setLayoutParameterToMatchParent() {
+        val layoutParameter = RecyclerView.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT)
+        itemView.layoutParams = layoutParameter
+    }
+}

--- a/os-arturito/src/main/java/com/outsmart/os_arturito/Components/ListComponent/OSAdapter.kt
+++ b/os-arturito/src/main/java/com/outsmart/os_arturito/Components/ListComponent/OSAdapter.kt
@@ -1,0 +1,157 @@
+package com.outsmart.os_arturito.Components.ListComponent
+
+import android.support.v7.widget.RecyclerView
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.outsmart.os_arturito.R
+
+abstract class OSAdapter<T>(
+        private var isInitialLoading: Boolean = true
+) : RecyclerView.Adapter<OSAdapter.OSViewHolder>() {
+
+    val dataList: MutableList<T> = mutableListOf()
+    private var placeHolderText = ""
+    private var paginationListener: GenericAdapterListener? = null
+    private var isPlaceholder = false
+    private var hasMoreItems = false
+    private val loadMoreLayout = R.layout.component_load_more
+    private val loadingLayout = R.layout.component_loading
+
+    init {
+        setupInitialLoading()
+    }
+
+    private fun setupInitialLoading() {
+        if (isInitialLoading) {
+            notifyDataSetChanged()
+        }
+    }
+
+    fun setDataToAdapterAndNotifyChanges(dataList: List<T>) {
+        clearDataAndCheckIfListIsEmpty(dataList)
+        notifyDataSetChanged()
+    }
+
+    fun setHasMoreItems(hasMoreItems: Boolean) {
+        this.hasMoreItems = hasMoreItems
+    }
+
+    private fun clearDataAndCheckIfListIsEmpty(dataList: List<T>) {
+        removeInitialLoading()
+        this.dataList.clear()
+        checkIfListIsNotEmpty(dataList)
+    }
+
+    private fun removeInitialLoading() {
+        isInitialLoading = false
+    }
+
+    private fun checkIfListIsNotEmpty(dataList: List<T>) {
+        if (dataList.isNotEmpty()) {
+            setNewDataAndRemovePlaceHolder(dataList)
+        } else {
+            addPlaceHolder()
+        }
+    }
+
+    private fun setNewDataAndRemovePlaceHolder(dataList: List<T>) {
+        this.dataList.addAll(dataList)
+        isPlaceholder = false
+    }
+
+    private fun addPlaceHolder() {
+        isPlaceholder = true
+    }
+
+    fun setPlaceHolderText(placeHolderText: String) {
+        this.placeHolderText = placeHolderText
+    }
+
+    fun setPaginationListener(paginationListener: GenericAdapterListener) {
+        this.paginationListener = paginationListener
+    }
+
+    override fun getItemCount(): Int {
+        return if (isPlaceholderOrInitialLoadingSet()) {
+            OSAdapterConstants.PLACEHOLDER_COUNT
+        } else {
+            getListSize()
+        }
+    }
+
+    private fun isPlaceholderOrInitialLoadingSet(): Boolean {
+        return isPlaceholder && placeHolderText.isNotBlank() || isInitialLoading
+    }
+
+    private fun getListSize(): Int {
+        return if (hasMoreItems) {
+            dataList.size.plus(1)
+        } else {
+            dataList.size
+        }
+    }
+
+    override fun getItemViewType(position: Int): Int {
+        return when {
+            isPlaceholderSet() -> OSAdapterConstants.PLACEHOLDER
+            isInitialLoading -> OSAdapterConstants.INITIAL_LOADING
+            checkForMoreItems(position) -> OSAdapterConstants.PAGE_LOADING
+            else -> setViewTypes(position)
+        }
+    }
+
+    private fun checkForMoreItems(position: Int): Boolean {
+        return position == dataList.size
+    }
+
+    private fun isPlaceholderSet(): Boolean {
+        return isPlaceholder && placeHolderText.isNotBlank()
+    }
+
+    abstract fun setViewTypes(position: Int): Int
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): OSViewHolder {
+        return when (viewType) {
+            OSAdapterConstants.PLACEHOLDER -> getPlaceholderViewHolder(parent)
+            OSAdapterConstants.PAGE_LOADING -> getLoadMoreViewHolder(parent)
+            OSAdapterConstants.INITIAL_LOADING -> getInitialLoadingViewHolder(parent)
+            else -> getViewHolder(parent, viewType)
+        }
+    }
+
+    private fun getInitialLoadingViewHolder(parent: ViewGroup): OSViewHolder {
+        return LoadingViewHolder(getInflatedLayout(parent, R.layout.component_loading))
+    }
+
+    private fun getLoadMoreViewHolder(parent: ViewGroup): OSViewHolder {
+        return PageLoadingViewHolder(getInflatedLayout(parent, loadMoreLayout))
+    }
+
+    private fun getInflatedLayout(parent: ViewGroup, layout: Int): View {
+        return LayoutInflater.from(parent.context).inflate(layout, parent, false)
+    }
+
+    abstract fun getViewHolder(parent: ViewGroup, viewType: Int): OSViewHolder
+
+    private fun getPlaceholderViewHolder(parent: ViewGroup): OSViewHolder {
+        return PlaceholderViewHolder(
+                itemView = PlaceholderView(context = parent.context),
+                placeholderText = placeHolderText)
+    }
+
+    override fun onBindViewHolder(holder: OSViewHolder, position: Int) {
+        holder.bindView(position)
+        paginateOnLastBind(position)
+    }
+
+    private fun paginateOnLastBind(position: Int) {
+        if (position == dataList.lastIndex) {
+            paginationListener?.paginate()
+        }
+    }
+
+    abstract class OSViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        abstract fun bindView(position: Int)
+    }
+}

--- a/os-arturito/src/main/java/com/outsmart/os_arturito/Components/ListComponent/OSAdapterConstants.kt
+++ b/os-arturito/src/main/java/com/outsmart/os_arturito/Components/ListComponent/OSAdapterConstants.kt
@@ -1,0 +1,9 @@
+package com.outsmart.os_arturito.Components.ListComponent
+
+object OSAdapterConstants {
+
+    const val PLACEHOLDER = 1000
+    const val PAGE_LOADING = 1001
+    const val INITIAL_LOADING = 1002
+    const val PLACEHOLDER_COUNT = 1
+}

--- a/os-arturito/src/main/java/com/outsmart/os_arturito/Components/ListComponent/PageLoadingViewHolder.kt
+++ b/os-arturito/src/main/java/com/outsmart/os_arturito/Components/ListComponent/PageLoadingViewHolder.kt
@@ -1,0 +1,10 @@
+package com.outsmart.os_arturito.Components.ListComponent
+
+import android.view.View
+
+class PageLoadingViewHolder(itemView: View) : OSAdapter.OSViewHolder(itemView) {
+
+    override fun bindView(position: Int) {
+        //no bind is needed, this is a visual holder
+    }
+}

--- a/os-arturito/src/main/java/com/outsmart/os_arturito/Components/ListComponent/PlaceholderView.kt
+++ b/os-arturito/src/main/java/com/outsmart/os_arturito/Components/ListComponent/PlaceholderView.kt
@@ -1,0 +1,21 @@
+package com.outsmart.os_arturito.Components.ListComponent
+
+import android.content.Context
+import android.support.constraint.ConstraintLayout
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import com.outsmart.os_arturito.R
+import kotlinx.android.synthetic.main.component_list_placeholder.view.*
+
+class PlaceholderView @JvmOverloads constructor(
+        context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
+) : ConstraintLayout(context, attrs, defStyleAttr) {
+
+    init {
+        LayoutInflater.from(context).inflate(R.layout.component_list_placeholder, this)
+    }
+
+    fun setText(placeholderText: String) {
+        listPlaceholderText.text = placeholderText
+    }
+}

--- a/os-arturito/src/main/java/com/outsmart/os_arturito/Components/ListComponent/PlaceholderViewHolder.kt
+++ b/os-arturito/src/main/java/com/outsmart/os_arturito/Components/ListComponent/PlaceholderViewHolder.kt
@@ -1,0 +1,23 @@
+package com.outsmart.os_arturito.Components.ListComponent
+
+import android.support.v7.widget.RecyclerView
+import android.view.View
+import android.view.ViewGroup
+
+class PlaceholderViewHolder(
+        itemView: View,
+        private val placeholderText: String) : OSAdapter.OSViewHolder(itemView) {
+
+    override fun bindView(position: Int) {
+        (itemView as PlaceholderView).setText(placeholderText)
+        setLayoutParametersToMatchParent(itemView)
+    }
+
+    private fun setLayoutParametersToMatchParent(itemView: PlaceholderView) {
+        val layoutParameter = RecyclerView.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT)
+        itemView.layoutParams = layoutParameter
+    }
+
+}

--- a/os-arturito/src/main/res/layout/component_list_placeholder.xml
+++ b/os-arturito/src/main/res/layout/component_list_placeholder.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/listPlaceholderText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="PLaceHolder" />
+
+</android.support.constraint.ConstraintLayout>

--- a/os-arturito/src/main/res/layout/component_load_more.xml
+++ b/os-arturito/src/main/res/layout/component_load_more.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ProgressBar xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_gravity="center">
+
+</ProgressBar>

--- a/os-arturito/src/main/res/layout/component_loading.xml
+++ b/os-arturito/src/main/res/layout/component_loading.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <ProgressBar
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</android.support.constraint.ConstraintLayout>


### PR DESCRIPTION
Como foi discutido no chapter de Android, fiz esse adapter no hackday. Alinhei com o design se este podia ser nossa lista padrão dos projetos.
As funcionalidades que já estão implementadas no adapter são:

- Loading inicial quando a tela é iniciada
- Placeholder com texto indicado que a lista está vazia (basta chamar o método setPlaceholderText(texto)).
- Loading no pé da lista ao iniciar uma paginação. Eu deixei esse loading dependente do hasMoreItems que vem do back.